### PR TITLE
7주차 과제 중간 업로드

### DIFF
--- a/chanyoung/week7/src/Main.js
+++ b/chanyoung/week7/src/Main.js
@@ -1,9 +1,11 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import App from './components/App';
-import HomePage from './pages/HomePage';
-import CoursePage from './pages/CoursePage';
-import CourseListPage from './pages/CourseListPage';
-import WishlistPage from './pages/WishlistPage';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import App from "./components/App";
+import HomePage from "./pages/HomePage";
+import CoursePage from "./pages/CoursePage";
+import CourseListPage from "./pages/CourseListPage";
+import QuestionListPage from "./pages/QuestionListPage";
+import QuestionPage from "./pages/QuestionPage";
+import WishlistPage from "./pages/WishlistPage";
 
 function Main() {
   return (
@@ -17,6 +19,8 @@ function Main() {
             element={<CoursePage />}
           />
           <Route path="wishlist" element={<WishlistPage />} />
+          <Route path="questions" element={<QuestionListPage />} />
+          <Route path="questions/616825" element={<QuestionPage />} />
         </Routes>
       </App>
     </BrowserRouter>

--- a/chanyoung/week7/src/components/CourseItem.js
+++ b/chanyoung/week7/src/components/CourseItem.js
@@ -1,10 +1,11 @@
-import Card from './Card';
-import CourseIcon from './CourseIcon';
-import Tags from './Tags';
-import getCourseColor from '../utils/getCourseColor';
-import styles from './CourseItem.module.css';
+import { Link } from "react-router-dom";
+import Card from "./Card";
+import CourseIcon from "./CourseIcon";
+import Tags from "./Tags";
+import getCourseColor from "../utils/getCourseColor";
+import styles from "./CourseItem.module.css";
 
-const DIFFICULTY = ['입문', '초급', '중급', '고급'];
+const DIFFICULTY = ["입문", "초급", "중급", "고급"];
 
 function CourseItem({ course }) {
   const showSummary = course.summary && course.title !== course.summary;
@@ -20,7 +21,9 @@ function CourseItem({ course }) {
         <CourseIcon photoUrl={course.photoUrl} />
       </div>
       <div className={styles.content}>
-        <h2 className={styles.title}>{course.title}</h2>
+        <h2 className={styles.title}>
+          <Link to={`/courses/${course.slug}`}>{course.title}</Link>
+        </h2>
         <p className={styles.description}>{showSummary && course.summary}</p>
         <div>
           <Tags values={[course.language, difficulty]} />

--- a/chanyoung/week7/src/components/Nav.js
+++ b/chanyoung/week7/src/components/Nav.js
@@ -1,16 +1,23 @@
-import Container from './Container';
-import UserMenu from './UserMenu';
-import logoImg from '../assets/logo.svg';
-import styles from './Nav.module.css';
+import { Link } from "react-router-dom";
+import Container from "./Container";
+import UserMenu from "./UserMenu";
+import logoImg from "../assets/logo.svg";
+import styles from "./Nav.module.css";
 
 function Nav() {
   return (
     <div className={styles.nav}>
       <Container className={styles.container}>
-        <img src={logoImg} alt="Codethat Logo" />
+        <Link to="/">
+          <img src={logoImg} alt="Codethat Logo" />
+        </Link>
         <ul className={styles.menu}>
-          <li>카탈로그</li>
-          <li>커뮤니티</li>
+          <li>
+            <Link to="/courses">카탈로그</Link>
+          </li>
+          <li>
+            <Link to="/questions">커뮤니티</Link>
+          </li>
           <li>
             <UserMenu />
           </li>

--- a/chanyoung/week7/src/components/UserMenu.js
+++ b/chanyoung/week7/src/components/UserMenu.js
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
-import personIcon from '../assets/person.png';
-import styles from './UserMenu.module.css';
+import { Link } from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
+import personIcon from "../assets/person.png";
+import styles from "./UserMenu.module.css";
 
 function UserMenu() {
   const [isOpen, setIsOpen] = useState(false);
@@ -14,10 +15,10 @@ function UserMenu() {
     if (!isOpen) return;
 
     const handleClickOutside = () => setIsOpen(false);
-    window.addEventListener('click', handleClickOutside);
+    window.addEventListener("click", handleClickOutside);
 
     return () => {
-      window.removeEventListener('click', handleClickOutside);
+      window.removeEventListener("click", handleClickOutside);
     };
   }, [isOpen]);
 
@@ -28,7 +29,9 @@ function UserMenu() {
       </button>
       {isOpen && (
         <ul className={styles.popup}>
-          <li>위시리스트</li>
+          <Link to="/wishlist">
+            <li>위시리스트</li>
+          </Link>
           <li className={styles.disabled}>회원가입</li>
           <li className={styles.disabled}>로그인</li>
         </ul>

--- a/chanyoung/week7/src/pages/QuestionListPage.js
+++ b/chanyoung/week7/src/pages/QuestionListPage.js
@@ -1,20 +1,21 @@
-import { useState } from 'react';
-import { getQuestions } from '../api';
-import DateText from '../components/DateText';
-import ListPage from '../components/ListPage';
-import Warn from '../components/Warn';
-import Card from '../components/Card';
-import Avatar from '../components/Avatar';
-import styles from './QuestionListPage.module.css';
-import searchBarStyles from '../components/SearchBar.module.css';
-import searchIcon from '../assets/search.svg';
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { getQuestions } from "../api";
+import DateText from "../components/DateText";
+import ListPage from "../components/ListPage";
+import Warn from "../components/Warn";
+import Card from "../components/Card";
+import Avatar from "../components/Avatar";
+import styles from "./QuestionListPage.module.css";
+import searchBarStyles from "../components/SearchBar.module.css";
+import searchIcon from "../assets/search.svg";
 
 function QuestionItem({ question }) {
   return (
     <Card className={styles.questionItem} key={question.title}>
       <div className={styles.info}>
         <p className={styles.title}>
-          {question.title}
+          <Link to={`/questions/${question.id}`}>{question.title}</Link>
           {question.answers.length > 0 && (
             <span className={styles.count}>[{question.answers.length}]</span>
           )}
@@ -34,7 +35,7 @@ function QuestionItem({ question }) {
 }
 
 function QuestionListPage() {
-  const [keyword, setKeyword] = useState('');
+  const [keyword, setKeyword] = useState("");
   const questions = getQuestions();
 
   const handleKeywordChange = (e) => setKeyword(e.target.value);


### PR DESCRIPTION
할 일: 커뮤니티 페이지 연결 구현
Routes 컴포넌트에서 리액트 라우터로 페이지 나누기
Nav 컴포넌트에 커뮤니티 페이지로 가는 링크 추가
QuestionListPage 컴포넌트에 각 상세 페이지로 가는 링크 추가

[개발 요구 사항]
1. /questions 로 들어가면 QuestionListPage 컴포넌트가 보이게 해 주세요.
2. /questions/616825 로 들어가면 QuestionPage 컴포넌트가 보이게 해 주세요.
3. 메뉴에서 '커뮤니티'를 클릭하면 /questions 로 이동합니다.
4. /questions 페이지에서 각 항목의 제목을 클릭하면 /questions/<해당 question의 id값> 으로 이동합니다. 그리고 맨 위의 항목을 클릭하면 /questions/616825 로 이동합니다.